### PR TITLE
Test and fix configuration writing, add signer configuration

### DIFF
--- a/action.js
+++ b/action.js
@@ -40,6 +40,7 @@ async function run() {
     const clientSecret = core.getInput('client-secret')
     const expectedArchiveChecksum = core.getInput('archive-checksum')
     const githubToken = core.getInput('github-token')
+    const signer = core.getInput('signer')
     const version = core.getInput('version')
 
     const platform = mapOS(os.platform())
@@ -95,12 +96,14 @@ async function run() {
 
     core.addPath(pathToCLI)
 
-    if (clientID || clientSecret) {
+    if (clientID || clientSecret || signer) {
       core.debug('writing signore config file')
       let configContent = ''
-      configContent += clientID ? `clientID: ${clientID}\n` : ''
-      configContent += clientSecret ? `clientSecret: ${clientSecret}\n` : ''
-      fs.writeFile(path.join(os.homedir(), '.signore', 'config.yaml'), configContent)
+      configContent += clientID ? `client_id: ${clientID}\n` : ''
+      configContent += clientSecret ? `client_secret: ${clientSecret}\n` : ''
+      configContent += signer ? `signer: ${signer}\n` : ''
+      await fs.mkdir(path.join(os.homedir(), '.signore'))
+      await fs.writeFile(path.join(os.homedir(), '.signore', 'config.yaml'), configContent)
     }
 
     core.debug('success: signore has been set up!')

--- a/action.test.js
+++ b/action.test.js
@@ -5,6 +5,7 @@ const os = require('os')
 
 const core = require('@actions/core')
 
+const relativeConfigPath = '.signore/config.yaml'
 const mockRelease = {
   assets: [
     {
@@ -33,7 +34,10 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
+  delete process.env['INPUT_CLIENT-ID']
+  delete process.env['INPUT_CLIENT-SECRET']
   process.env['INPUT_GITHUB-TOKEN'] = 'testtoken'
+  delete process.env.INPUT_SIGNER
   process.env.INPUT_VERSION = 'latest'
   process.env['INPUT_VERSION-CHECKSUM'] = '5663389ef1a8ec48af6ca622e66bf0f54ba8f22c127f14cb8a3f429e40868582'
 
@@ -93,6 +97,87 @@ describe('action', () => {
       expect(scope.isDone()).toBeTruthy()
       expect(spyCoreAddPath).toHaveBeenCalled()
       expect(spyCoreSetOutput).toHaveBeenCalledWith('version', 'v0.1.3')
+      done()
+    })
+  })
+
+  test('configures client-id', (done) => {
+    const scope = nock('https://api.github.com')
+      .get('/repos/hashicorp/signore/releases/tags/v0.1.3')
+      .reply(200, mockRelease)
+      .get('/repos/hashicorp/signore/releases/assets/3')
+      .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' })
+
+    fs.mkdtemp(path.join(os.tmpdir(), 'setup-signore-'), async (err, directory) => {
+      if (err) throw err
+
+      process.env['INPUT_CLIENT-ID'] = 'testclientid'
+      process.env.INPUT_VERSION = 'v0.1.3'
+      process.env.RUNNER_TEMP = directory
+
+      const spyOsHomedir = jest.spyOn(os, 'homedir')
+      spyOsHomedir.mockReturnValue(directory)
+
+      const action = require('./action')
+      await expect(await action()).resolves
+      expect(scope.isDone()).toBeTruthy()
+
+      const config = fs.readFileSync(path.resolve(directory, relativeConfigPath), { encoding: 'utf8' })
+      expect(config).toEqual('client_id: testclientid\n')
+      done()
+    })
+  })
+
+  test('configures client-secret', (done) => {
+    const scope = nock('https://api.github.com')
+      .get('/repos/hashicorp/signore/releases/tags/v0.1.3')
+      .reply(200, mockRelease)
+      .get('/repos/hashicorp/signore/releases/assets/3')
+      .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' })
+
+    fs.mkdtemp(path.join(os.tmpdir(), 'setup-signore-'), async (err, directory) => {
+      if (err) throw err
+
+      process.env['INPUT_CLIENT-SECRET'] = 'testclientsecret'
+      process.env.INPUT_VERSION = 'v0.1.3'
+      process.env.RUNNER_TEMP = directory
+
+      const spyOsHomedir = jest.spyOn(os, 'homedir')
+      spyOsHomedir.mockReturnValue(directory)
+
+      const action = require('./action')
+      await expect(await action()).resolves
+      expect(scope.isDone()).toBeTruthy()
+
+      const config = fs.readFileSync(path.resolve(directory, relativeConfigPath), { encoding: 'utf8' })
+      expect(config).toEqual('client_secret: testclientsecret\n')
+      done()
+    })
+  })
+
+  test('configures signer', (done) => {
+    const scope = nock('https://api.github.com')
+      .get('/repos/hashicorp/signore/releases/tags/v0.1.3')
+      .reply(200, mockRelease)
+      .get('/repos/hashicorp/signore/releases/assets/3')
+      .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' })
+
+    fs.mkdtemp(path.join(os.tmpdir(), 'setup-signore-'), async (err, directory) => {
+      if (err) throw err
+
+      process.env.INPUT_SIGNER = 'testsigner'
+      process.env.INPUT_VERSION = 'v0.1.3'
+      process.env.RUNNER_TEMP = directory
+
+      const spyOsHomedir = jest.spyOn(os, 'homedir')
+      spyOsHomedir.mockReturnValue(directory)
+
+      const action = require('./action')
+      await expect(await action()).resolves
+      expect(scope.isDone()).toBeTruthy()
+
+      const config = fs.readFileSync(path.resolve(directory, relativeConfigPath), { encoding: 'utf8' })
+      expect(config).toEqual('signer: testsigner\n')
       done()
     })
   })

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'The client secret of your signing client to add to the signore config (optional)'
     required: false
     default: ''
+  signer:
+    description: 'The signer to add to the signore config (optional)'
+    required: false
+    default: ''
   version:
     description: 'The version of the signore CLI to install. Defaults to the most recent version.'
     required: false


### PR DESCRIPTION
Previously, if the `.signore` directory did not exist, it would return an error. Also fixes the configuration keys to match the `signore` command expectations.