### PR TITLE
Update action NodeJS version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ outputs:
   version:
     description: 'The version of the signore CLI that was installed.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Closes #68 

Testing was recently updated to NodeJS 16 in #59 -- this change makes it so GitHub Actions will automatically use NodeJS 16 for the action.