### PR TITLE
SECS-3039: Migrated secrets and runners to CRT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           github-token: ${{ steps.secrets.outputs.SIGNORE_REPO_GITHUB_TOKEN }}
       - name: Print installed signore version
-        run: echo "Installed signore ${{steps.install.outputs.version}}"
+        run: echo "Installed signore ${{ steps.install.outputs.version }}"
       - name: Run `signore version`
         run: signore version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,26 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'ondemand']
     name: test the action by using it
     steps:
+      - name: Authenticate to Vault
+        id: vault-auth
+        run: vault-auth
+      - name: Fetch Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.7.3
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets: |
+            kv/data/github/hashicorp/setup-signore SIGNORE_REPO_GITHUB_TOKEN;
       - name: Install signore
         id: install
         uses: hashicorp/setup-signore@main
         with:
-          github-token: ${{secrets.SIGNORE_REPO_GITHUB_TOKEN}}
+          github-token: ${{ steps.secrets.outputs.SIGNORE_REPO_GITHUB_TOKEN }}
       - name: Print installed signore version
         run: echo "Installed signore ${{steps.install.outputs.version}}"
       - name: Run `signore version`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'ondemand']
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1


### PR DESCRIPTION
## TLDR
Migrating secrets to CRT vault and runners to self hosted.

## Description
Migrating secrets to CRT vault and runners to self hosted to meet required company standards

## Fixes
https://hashicorp.atlassian.net/browse/SECS-3039

## Type of change
GHA config

## How Has This Been Tested?
GHA runs will complete on PR

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I’ve documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I’ve worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I’ve worked with GRC to ensure compliance due to a significant change to the cardholder data environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-core). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
