### PR TITLE
SECS-5223: New owners: team-selfmanaged-releng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/team-cloudsec
+* @hashicorp/team-selfmanaged-releng

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -4,8 +4,8 @@
 ---
 schema: 1.1
 
-partition: security
-category: cloudsec
+partition: release-engineering
+category: github-action 
 
 summary:
-  owner: team-cloudsec
+  owner: team-self-managed-releng

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -8,4 +8,4 @@ partition: release-engineering
 category: github-action 
 
 summary:
-  owner: team-self-managed-releng
+  owner: team-selfmanaged-releng

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -5,7 +5,7 @@
 schema: 1.1
 
 partition: release-engineering
-category: github-action 
+category: github-action
 
 summary:
   owner: team-selfmanaged-releng

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ and defaults.
 - How do I get a GitHub token with access to the signore repository?
   - TBD
 - How do I get access to the signore signing service?
-  - For now... talk to [Miles](mcrabill@hashicorp.com)
+  - For now... talk to `team-selfmanaged-releng`.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## TLDR

This transfers CODEOWNERS and updates Heimdall metadata to the new owners: team-selfmanaged-releng

## Fixes

SECS-5223.

## Type of change

Metadata.

## How Has This Been Tested?

Once the passport proposals are approved, the CODEOWNERS changes should show no errors.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I’ve documented a plan to revert these changes if they
      require more than reverting the pull request.

- [ ] If applicable, I’ve worked with GRC to document the impact of any changes
      to security controls.

  Examples of changes to controls include access controls, encryption, logging,
  etc.

- [ ] If applicable, I’ve worked with GRC to ensure compliance due to a
      significant change to the cardholder data environment.

  Examples include changes to operating systems, ports, protocols, services,
  cryptography-related components, PII processing code, etc.

If you have any questions, please contact your direct supervisor, GRC
(#team-grc), or the PCI working group (#proj-pci-core). You can also find more
information at
[PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
