### PR TITLE
Upgrade Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ outputs:
   version:
     description: 'The version of the signore CLI that was installed.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
This bump is necessary in order to prevent workflows from breaking with the upcoming nodejs default being set to 24 on june 16th

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/